### PR TITLE
Add Pterodactyl egg with auto-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # Niactyl
+
+This project provides a simple full‑stack example using a fast Node.js server and a Vite + React front‑end styled with Tailwind CSS. The UI defaults to a dark theme and includes Discord authentication. On first login a Pterodactyl user is created or associated with the Discord account.
+
+## Getting Started
+
+1. Install dependencies for both the server and client:
+   ```bash
+   cd server && npm install
+ cd ../client && npm install
+  ```
+2. Copy `server/config.yml` and adjust the values for your Discord OAuth and Pterodactyl panel.
+3. (Optional) edit `client/src/config.ts` if you need to change the API base URL.
+4. Build the React front‑end:
+   ```bash
+   npm run build
+   ```
+5. Start the Node server from the `server` directory:
+   ```bash
+   npm start
+   ```
+   The application will be available at `http://localhost:3000`.
+
+During development you can run `npm run dev` in both `client` and `server` directories for hot‑reloading.
+
+## Pterodactyl Egg
+
+A sample egg is available at `pterodactyl/niactyl-egg.json`. Import this into your Pterodactyl panel to deploy the app. Set the `GIT_REPO` variable to your repository URL and keep `AUTO_UPDATE` enabled to pull updates on each restart.
+

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Niactyl App</title>
+  </head>
+  <body class="bg-gray-900 text-white">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "niactyl-client",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.3.0",
+    "typescript": "^5.2.0",
+    "vite": "^4.5.0"
+  }
+}

--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import config from './config';
+
+function Home({ message, user }) {
+  return user ? (
+    <Navigate to="/dashboard" replace />
+  ) : (
+    <div className="text-center">
+      <p className="mb-4 text-xl text-gray-300">{message}</p>
+      <a
+        href="/auth/discord"
+        className="px-4 py-2 bg-blue-600 rounded hover:bg-blue-700"
+      >
+        Login with Discord
+      </a>
+    </div>
+  );
+}
+
+function Dashboard({ user }) {
+  return (
+    <div className="text-center">
+      <p className="mb-4 text-xl text-gray-300">Welcome, {user.username}!</p>
+      <a href="/logout" className="underline text-blue-400">Logout</a>
+    </div>
+  );
+}
+
+function App() {
+  const [message, setMessage] = useState('Loading...');
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    fetch(`${config.apiBase}/api/message`)
+      .then((res) => res.json())
+      .then((data) => setMessage(data.message))
+      .catch((err) => {
+        console.error(err);
+        setMessage('Error fetching message');
+      });
+    fetch(`${config.apiBase}/api/user`)
+      .then((res) => res.json())
+      .then((data) => setUser(data.user))
+      .catch(() => setUser(null));
+  }, []);
+
+  return (
+    <BrowserRouter>
+      <div className="min-h-screen flex flex-col items-center justify-center p-8">
+        <h1 className="text-4xl font-bold mb-4">Niactyl App</h1>
+        <Routes>
+          <Route path="/" element={<Home message={message} user={user} />} />
+          <Route
+            path="/dashboard"
+            element={user ? <Dashboard user={user} /> : <Navigate to="/" />}
+          />
+        </Routes>
+      </div>
+    </BrowserRouter>
+  );
+}
+
+export default App;

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -1,0 +1,5 @@
+const config = {
+  apiBase: import.meta.env.VITE_API_BASE || '',
+};
+
+export default config;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  darkMode: 'class',
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/pterodactyl/niactyl-egg.json
+++ b/pterodactyl/niactyl-egg.json
@@ -1,0 +1,41 @@
+{
+  "meta": {
+    "version": "PTDL_v2",
+    "update_url": null
+  },
+  "name": "Niactyl",
+  "description": "Fullstack app with Discord auth and Pterodactyl user integration. Automatically pulls updates from GitHub.",
+  "docker_images": {
+    "nodejs": "ghcr.io/parkervcp/yolks:nodejs_18"
+  },
+  "file_denylist": [],
+  "startup": "bash startup.sh",
+  "scripts": {
+    "installation": {
+      "script": "apt-get update\napt-get install -y git\nif [ -d /mnt/server/.git ]; then rm -rf /mnt/server/*; fi\ngit clone --depth=1 ${GIT_REPO} /mnt/server\ncd /mnt/server/server && npm install\ncd /mnt/server/client && npm install && npm run build",
+      "container": "debian:bookworm-slim",
+      "entrypoint": "bash"
+    }
+  },
+  "variables": [
+    {
+      "name": "Git Repository",
+      "description": "Repository to pull the project from",
+      "env_variable": "GIT_REPO",
+      "default_value": "https://github.com/username/Niactyl.git",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "required|string"
+    },
+    {
+      "name": "Auto Update",
+      "description": "Pull latest changes on startup if set to 1",
+      "env_variable": "AUTO_UPDATE",
+      "default_value": "1",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "required|boolean"
+    }
+  ]
+}
+

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,18 @@
+# Niactyl Server
+
+A Fastify server that serves API endpoints, handles Discord authentication and creates/associates Pterodactyl users. Static assets are served from the built React app.
+
+## Available scripts
+
+- `npm run start` - start the server (after installing dependencies)
+- `npm run dev` - run the server in development
+
+## Endpoints
+
+- `GET /api/message` - returns a JSON greeting
+- `GET /api/user` - returns the logged in Discord user or `null`
+- `GET /auth/discord` - redirect to Discord OAuth
+- `GET /auth/discord/callback` - OAuth callback
+- `GET /logout` - destroy the session
+
+Static files from `../client/dist` are also served.

--- a/server/config.yml
+++ b/server/config.yml
@@ -1,0 +1,10 @@
+sessionSecret: change_me
+
+discord:
+  clientId: "DISCORD_CLIENT_ID"
+  clientSecret: "DISCORD_CLIENT_SECRET"
+  callbackUrl: "http://localhost:3000/auth/discord/callback"
+
+pterodactyl:
+  panelUrl: "https://panel.example.com"
+  apiKey: "APPLICATION_API_KEY"

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,123 @@
+import Fastify from 'fastify';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import fastifyStatic from '@fastify/static';
+import cors from '@fastify/cors';
+import fastifyCookie from '@fastify/cookie';
+import fastifySession from '@fastify/session';
+import fastifyOauth2 from '@fastify/oauth2';
+import fs from 'fs';
+import YAML from 'yaml';
+import fetch from 'node-fetch';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const fastify = Fastify({ logger: true });
+
+const configPath = path.join(__dirname, 'config.yml');
+const config = YAML.parse(fs.readFileSync(configPath, 'utf8'));
+
+await fastify.register(cors);
+await fastify.register(fastifyCookie);
+await fastify.register(fastifySession, {
+  secret: config.sessionSecret || 'change_this',
+  cookie: { secure: false },
+});
+
+await fastify.register(fastifyOauth2, {
+  name: 'discordOAuth2',
+  scope: ['identify', 'email'],
+  credentials: {
+    client: {
+      id: config.discord.clientId,
+      secret: config.discord.clientSecret,
+    },
+    auth: {
+      authorizeHost: 'https://discord.com',
+      authorizePath: '/oauth2/authorize',
+      tokenHost: 'https://discord.com',
+      tokenPath: '/api/oauth2/token',
+    },
+  },
+  startRedirectPath: '/auth/discord',
+  callbackUri: config.discord.callbackUrl,
+});
+
+fastify.get('/api/message', async () => {
+  return { message: 'Hello from server!' };
+});
+
+fastify.get('/api/user', async (req) => {
+  return { user: req.session.user || null };
+});
+
+fastify.get('/auth/discord/callback', async function (req, reply) {
+  const token = await this.discordOAuth2.getAccessTokenFromAuthorizationCodeFlow(req);
+  const userRes = await fetch('https://discord.com/api/users/@me', {
+    headers: { Authorization: `Bearer ${token.access_token}` },
+  });
+  const discordUser = await userRes.json();
+  req.session.user = discordUser;
+  await ensurePteroUser(discordUser);
+  reply.redirect('/dashboard');
+});
+
+fastify.get('/logout', async (req, reply) => {
+  await req.destroySession();
+  reply.redirect('/');
+});
+
+await fastify.register(fastifyStatic, {
+  root: path.join(__dirname, '../client/dist'),
+  prefix: '/',
+});
+
+fastify.get('*', async (req, reply) => {
+  return reply.sendFile('index.html');
+});
+
+fastify.listen({ port: 3000 }, (err, address) => {
+  if (err) {
+    fastify.log.error(err);
+    process.exit(1);
+  }
+  fastify.log.info(`Server listening at ${address}`);
+});
+
+async function ensurePteroUser(discordUser) {
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${config.pterodactyl.apiKey}`,
+  };
+  try {
+    // Attempt to find existing user by external_id
+    const res = await fetch(
+      `${config.pterodactyl.panelUrl}/api/application/users?filter[external_id]=${discordUser.id}`,
+      { headers }
+    );
+    const data = await res.json();
+    if (data.data && data.data.length > 0) {
+      return data.data[0];
+    }
+
+    // If not found, create one
+    const createRes = await fetch(
+      `${config.pterodactyl.panelUrl}/api/application/users`,
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          username: discordUser.username,
+          email: discordUser.email,
+          first_name: discordUser.username,
+          last_name: 'Niactyl',
+          external_id: discordUser.id,
+        }),
+      }
+    );
+    return await createRes.json();
+  } catch (err) {
+    fastify.log.error(err);
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "niactyl-server",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "node index.js"
+  },
+  "dependencies": {
+    "fastify": "^4.23.2",
+    "@fastify/static": "^6.9.0",
+    "@fastify/cors": "^8.4.0",
+    "@fastify/cookie": "^8.2.0",
+    "@fastify/session": "^7.1.0",
+    "@fastify/oauth2": "^7.2.0",
+    "node-fetch": "^3.3.1",
+    "yaml": "^2.3.0"
+  }
+}

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+if [ "$AUTO_UPDATE" = "1" ] && [ -d .git ]; then
+  git pull
+  cd server && npm install
+  cd ../client && npm install && npm run build
+  cd ..
+fi
+
+node server/index.js
+


### PR DESCRIPTION
## Summary
- provide a Pterodactyl egg that clones the repo and can auto update
- add a startup script used by the egg
- document using the egg in README

## Testing
- `npm test` in `server` *(fails: Missing script)*
- `npm test` in `client` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ea3cc575c832ba4a7c73950586c1a