### PR TITLE
Simplify startup logs

### DIFF
--- a/server/config.yml
+++ b/server/config.yml
@@ -1,4 +1,5 @@
 sessionSecret: change_me
+domain: "http://localhost:3000"
 
 discord:
   clientId: "DISCORD_CLIENT_ID"


### PR DESCRIPTION
## Summary
- turn off Fastify's built-in logger
- print missing static files warning with `console.warn`
- use `console.error` for startup and helper errors
- pass config to `ensurePteroUser`
- show single lime-colored ready message

## Testing
- `node -c server/index.js`
- `npm -C server run build` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686f967a8654832bbb4fbaaac32c1a82