### PR TITLE
Simplify startup logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Run the following commands to install dependencies:
 
 ```bash
 cd server && npm install
-cd ../client && npm install && npm run build
+cd ../client && npm install
+npm run build # or enable devMode in server/config.yml
 cd ..
 ```
 
@@ -31,3 +32,5 @@ cd client && npm run build
 ```
 
 Running `startup.sh` will perform this build automatically whenever the `client/dist` directory is absent.
+
+To skip building the client entirely during development, set `devMode: true` in `server/config.yml`. The server will then start the client dev server using `npm run dev`.

--- a/server/config.yml
+++ b/server/config.yml
@@ -1,4 +1,6 @@
 sessionSecret: change_me
+domain: "http://localhost:3000"
+devMode: false
 
 discord:
   clientId: "DISCORD_CLIENT_ID"


### PR DESCRIPTION
## Summary
- turn off Fastify's built-in logger
- print missing static files warning with `console.warn`
- use `console.error` for startup and helper errors
- pass config to `ensurePteroUser`
- show single lime-colored ready message
- add devMode config and automatically run `npm run dev` when enabled

## Testing
- `node -c server/index.js`
- `npm -C server run build` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686f967a8654832bbb4fbaaac32c1a82