### PR TITLE
Hide missing static files warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,10 +80,6 @@ fastify.get('/logout', async (req, reply) => {
     fastify.setNotFoundHandler((req, reply) => {
       reply.sendFile('index.html');
     });
-  } else {
-    console.warn(
-      `Static files not found at ${distPath}. Run 'npm run build' in the client directory.`
-    );
   }
 
   fastify.listen({ port: 3000 }, (err) => {


### PR DESCRIPTION
## Summary
- remove console warning when client build artifacts are missing

## Testing
- `node -c index.js`

------
https://chatgpt.com/codex/tasks/task_e_686fb8999d94832b8b9b519c40bd6994