### PR TITLE
Update to Node.js 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Niactyl
 
-Fullstack application with a Fastify backend and simple frontend. Requires Node.js 18 or newer. The server now stores data in a PostgreSQL database via Prisma and automatically imports eggs and nodes from your Pterodactyl panel.
+Fullstack application with a Fastify backend and simple frontend. Requires Node.js 22 or newer. The server now stores data in a PostgreSQL database via Prisma and automatically imports eggs and nodes from your Pterodactyl panel.
 
 ## Getting Started
 

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,9 @@
     "build": "vite build",
     "preview": "vite preview"
   },
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "start": "node index.js",
     "dev": "node index.js"
   },
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "fastify": "^5.4.0",
     "@fastify/static": "^8.2.0",


### PR DESCRIPTION
## Summary
- require Node.js 22 in docs
- specify Node.js 22 in `package.json` and `client/package.json`

## Testing
- `npm run test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_686fdfabf970832b8e81b4694ba8cdd1