### PR TITLE
Automate Postgres setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then start the server:
 node index.js
 ```
 
-You can also run the provided `startup.sh` script which will install dependencies if they do not exist and start the server:
+You can also run the provided `startup.sh` script which will install dependencies if they do not exist and start the server. When the configured database host is `localhost`, the script will also install and start PostgreSQL and create the configured user and database automatically:
 
 ```bash
 bash startup.sh

--- a/startup.sh
+++ b/startup.sh
@@ -7,15 +7,33 @@ if [ "$AUTO_UPDATE" = "1" ] && [ -d .git ]; then
   git reset --hard origin/main
 fi
 
-# Load DATABASE_URL from config.yml when not set
-if [ -z "$DATABASE_URL" ] && [ -f config.yml ]; then
+# Load database configuration from config.yml
+if [ -f config.yml ]; then
     DB_USER=$(grep '^[ ]*user:' config.yml | awk '{print $2}' | tr -d '"')
     DB_PASS=$(grep '^[ ]*password:' config.yml | awk '{print $2}' | tr -d '"')
     DB_HOST=$(grep '^[ ]*host:' config.yml | awk '{print $2}' | tr -d '"')
     DB_PORT=$(grep '^[ ]*port:' config.yml | awk '{print $2}' | tr -d '"')
     DB_NAME=$(grep '^[ ]*name:' config.yml | awk '{print $2}' | tr -d '"')
+fi
+
+# Build DATABASE_URL from config.yml when not already set
+if [ -z "$DATABASE_URL" ] && [ -n "$DB_USER" ]; then
     DATABASE_URL="postgresql://${DB_USER}:${DB_PASS}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
-  export DATABASE_URL
+    export DATABASE_URL
+fi
+
+# Ensure PostgreSQL is installed and running for local databases
+if [ "$DB_HOST" = "localhost" ] || [ "$DB_HOST" = "127.0.0.1" ]; then
+  if ! command -v psql >/dev/null 2>&1; then
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql > /dev/null
+  fi
+  service postgresql start
+
+  sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='${DB_USER}'" | grep -q 1 || \
+    sudo -u postgres psql -c "CREATE USER \"$DB_USER\" WITH PASSWORD '$DB_PASS';"
+  sudo -u postgres psql -tc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" | grep -q 1 || \
+    sudo -u postgres psql -c "CREATE DATABASE \"$DB_NAME\" OWNER \"$DB_USER\";"
 fi
 
 if [ "$AUTO_UPDATE" = "1" ] || [ ! -d node_modules ]; then


### PR DESCRIPTION
## Summary
- load DB config unconditionally in `startup.sh`
- automatically install and start PostgreSQL
- create the configured user and database when using a local DB
- document new behaviour in README

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_686fe6094dc0832bb8af29871321c06d