### PR TITLE
Fix Prisma error by pushing schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Run the following commands to install dependencies:
 ```bash
 npm install
 npx prisma generate
+npx prisma db push
 cd client && npm install && npm run build
 cd ..
 ```
@@ -29,7 +30,7 @@ You can also run the provided `startup.sh` script which will install dependencie
 bash startup.sh
 ```
 
-The script builds `DATABASE_URL` from the `database` section in `config.yml` when not already set and runs `npx prisma generate` whenever packages are installed.
+The script builds `DATABASE_URL` from the `database` section in `config.yml` when not already set and runs `npx prisma generate` and `npx prisma db push` whenever packages are installed.
 
 If you see a warning about missing static files when starting the server, build the client:
 

--- a/startup.sh
+++ b/startup.sh
@@ -40,6 +40,8 @@ if [ "$AUTO_UPDATE" = "1" ] || [ ! -d node_modules ]; then
   npm install
   npx prisma generate
 fi
+# Ensure database tables are created from the Prisma schema
+npx prisma db push
 
 if [ "$AUTO_UPDATE" = "1" ] || [ ! -d client/node_modules ]; then
   cd client && npm install


### PR DESCRIPTION
## Summary
- ensure Prisma schema is applied by running `npx prisma db push`
- document the new setup step in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686fedef5730832b948c3b7ac5e0902a