### PR TITLE
Use config domain for server and Vite

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,6 +1,20 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import fs from 'fs';
+import path from 'path';
+import YAML from 'yaml';
+
+const configPath = path.resolve(__dirname, '../config.yml');
+const config = YAML.parse(fs.readFileSync(configPath, 'utf8'));
+const { hostname, port } = new URL(config.domain);
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: hostname,
+    port: port ? parseInt(port, 10) : 5173,
+  },
+  define: {
+    'import.meta.env.VITE_API_BASE': JSON.stringify(config.domain),
+  },
 });

--- a/index.js
+++ b/index.js
@@ -59,7 +59,9 @@ async function start() {
     reply.redirect('/');
   });
 
-  fastify.listen({ port: 3000 }, (err) => {
+  const { hostname, port } = new URL(config.domain);
+  const listenPort = port ? parseInt(port, 10) : 3000;
+  fastify.listen({ host: hostname, port: listenPort }, (err) => {
     if (err) {
       console.error(err);
       process.exit(1);


### PR DESCRIPTION
## Summary
- derive Fastify host/port from `config.yml`
- configure Vite dev server and API base from `config.yml`

## Testing
- `npm install`
- `npm install --prefix client`
- `npm run --silent -C client build`
- `node index.js` *(fails: connect ENETUNREACH 5.249.164.28:5432)*

------
https://chatgpt.com/codex/tasks/task_e_686ff27cc828832ba5a15f12e822f564