### PR TITLE
Add configurable listen address

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ The server uses **Prisma** with a PostgreSQL database to store users, eggs and n
 
 The server will automatically create the configured database if it does not already exist.
 
+The server listens on the host and port specified under the `listen` section in
+`config.yml`. If this section is omitted, the host and port are derived from the
+`domain` value.
+
 Then start the server:
 
 ```bash

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,8 @@
 sessionSecret: DAhxwoVlWpWSfeNIsJeFrb9dx19hwlSK
 domain: "http://op-1.firecone.eu:1066"
+listen:
+  host: "0.0.0.0"
+  port: 1066
 
 discord:
   clientId: "1142540615633076244"

--- a/index.js
+++ b/index.js
@@ -59,9 +59,17 @@ async function start() {
     reply.redirect('/');
   });
 
-  const { hostname, port } = new URL(config.domain);
-  const listenPort = port ? parseInt(port, 10) : 3000;
-  fastify.listen({ host: hostname, port: listenPort }, (err) => {
+  let listenHost;
+  let listenPort;
+  if (config.listen && (config.listen.host || config.listen.port)) {
+    listenHost = config.listen.host || '0.0.0.0';
+    listenPort = config.listen.port || 3000;
+  } else {
+    const { hostname, port } = new URL(config.domain);
+    listenHost = hostname;
+    listenPort = port ? parseInt(port, 10) : 3000;
+  }
+  fastify.listen({ host: listenHost, port: listenPort }, (err) => {
     if (err) {
       console.error(err);
       process.exit(1);


### PR DESCRIPTION
## Summary
- allow overriding server host/port via `listen` config section
- document listen section in README
- default to `0.0.0.0:1066` in sample `config.yml`

## Testing
- `npm install`
- `npx prisma generate`
- `npx prisma db push` *(fails: Can't reach database server)*
- `node index.js` *(fails: connect ENETUNREACH 5.249.164.28:5432)*

------
https://chatgpt.com/codex/tasks/task_e_687004876eb4832bbef3d47883995718