### PR TITLE
Fix frontend path

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -19,7 +19,8 @@
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.11",
         "typescript": "^5.8.3",
-        "vite": "^7.0.4"
+        "vite": "^7.0.4",
+        "yaml": "^2.8.0"
       },
       "engines": {
         "node": ">=22"
@@ -2513,6 +2514,19 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
     }
   },
   "dependencies": {
@@ -3818,6 +3832,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
+    "yaml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
       "dev": true
     }
   }

--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "@vitejs/plugin-react": "^4.6.0",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
+    "yaml": "^2.8.0",
     "@tailwindcss/postcss": "^4.1.11",
     "tailwindcss": "^4.1.11",
     "typescript": "^5.8.3",

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ async function start() {
 
   await importEggsAndNodes();
 
-  const distPath = path.join(__dirname, '../client/dist');
+  const distPath = path.join(__dirname, 'client', 'dist');
   if (fs.existsSync(distPath)) {
     await fastify.register(fastifyStatic, {
       root: distPath,


### PR DESCRIPTION
## Summary
- correct path to client build output so the server can serve static files

## Testing
- `npm install` in root and client
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870079a2870832ba0a43836ef60708a