### PR TITLE
Fix Discord OAuth token handling

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -26,7 +26,7 @@ export default async function (fastify, opts) {
   });
 
   fastify.get('/auth/discord/callback', async function (req, reply) {
-    const token = await this.discordOAuth2.getAccessTokenFromAuthorizationCodeFlow(req);
+    const { token } = await this.discordOAuth2.getAccessTokenFromAuthorizationCodeFlow(req);
     const userRes = await fetch('https://discord.com/api/users/@me', {
       headers: { Authorization: `Bearer ${token.access_token}` },
     });


### PR DESCRIPTION
## Summary
- handle returned OAuth2 token correctly when fetching Discord user info

## Testing
- `node --check index.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68701c0ae900832ba42c0b89314584b2