### PR TITLE
Implement new /auth page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import config from './config';
+import Auth from './Auth';
 
 function Home({ message, user }) {
   return user ? (
@@ -51,9 +52,10 @@ function App() {
         <h1 className="text-4xl font-bold mb-4">Niactyl App</h1>
         <Routes>
           <Route path="/" element={<Home message={message} user={user} />} />
+          <Route path="/auth" element={<Auth />} />
           <Route
             path="/dashboard"
-            element={user ? <Dashboard user={user} /> : <Navigate to="/" />}
+            element={user ? <Dashboard user={user} /> : <Navigate to="/auth" />}
           />
         </Routes>
       </div>

--- a/client/src/Auth.jsx
+++ b/client/src/Auth.jsx
@@ -1,0 +1,77 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import config, { APP_NAME, BRAND_COLOR, TOS_URL, DISCORD_COLOR } from './config';
+
+const CURRENT_YEAR = new Date().getFullYear();
+
+function Auth() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    fetch(`${config.apiBase}/api/user`, { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data && data.user) navigate('/dashboard');
+      })
+      .catch(() => {});
+  }, [navigate]);
+
+  return (
+    <>
+      <link
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Rubik:wght@500;700&display=swap"
+        rel="stylesheet"
+      />
+      <div className="min-h-screen bg-[#0C0E14] flex flex-col items-center justify-center px-4 font-[Inter]">
+        <div className="bg-[#14171F] rounded-xl p-10 w-full max-w-md text-center">
+          <h1
+            className="text-3xl font-bold text-[#F7F7F7] mb-1"
+            style={{ fontFamily: 'Rubik, sans-serif' }}
+          >
+            Welcome to
+          </h1>
+          <h2
+            className="text-4xl font-extrabold mb-6"
+            style={{ fontFamily: 'Rubik, sans-serif', color: BRAND_COLOR }}
+          >
+            {APP_NAME}
+          </h2>
+          <button
+            onClick={() => (window.location.href = `${config.apiBase}/auth/discord`)}
+            className="flex items-center justify-center gap-3 px-6 py-3 rounded-lg text-sm font-semibold transition hover:bg-[#1e1e1e] w-full"
+            style={{
+              backgroundColor: 'transparent',
+              border: `2.5px solid ${DISCORD_COLOR}`,
+              color: DISCORD_COLOR,
+            }}
+          >
+            <img
+              src="https://cdn.prod.website-files.com/6257adef93867e50d84d30e2/66e3d80db9971f10a9757c99_Symbol.svg"
+              alt="Discord"
+              className="w-5 h-5"
+            />
+            Login with Discord
+          </button>
+          <p className="text-[#aaaaaa] text-xs mt-5 font-normal">
+            By continuing, you agree to our{' '}
+            <a
+              href={TOS_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:underline"
+              style={{ color: BRAND_COLOR }}
+            >
+              Terms of Service
+            </a>
+            .
+          </p>
+        </div>
+        <p className="mt-4 text-sm font-normal" style={{ color: BRAND_COLOR }}>
+          © {CURRENT_YEAR} {APP_NAME} | Powered by Niactyl
+        </p>
+      </div>
+    </>
+  );
+}
+
+export default Auth;

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -1,3 +1,8 @@
+export const APP_NAME = 'Niactyl';
+export const BRAND_COLOR = '#7c3aed';
+export const DISCORD_COLOR = '#5865F2';
+export const TOS_URL = '#';
+
 const config = {
   apiBase: import.meta.env.VITE_API_BASE || '',
 };


### PR DESCRIPTION
## Summary
- add a login page component
- expose branding constants
- add /auth route to `App.jsx`
- rename `Login.jsx` to `Auth.jsx`

## Testing
- `npm --prefix client run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68701c9b4430832b93423cef7dda6714