### PR TITLE
Force login redirect

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,20 +3,8 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import config from './config';
 import Auth from './Auth';
 
-function Home({ message, user }) {
-  return user ? (
-    <Navigate to="/dashboard" replace />
-  ) : (
-    <div className="text-center">
-      <p className="mb-4 text-xl text-gray-300">{message}</p>
-      <a
-        href="/auth/discord"
-        className="px-4 py-2 bg-blue-600 rounded hover:bg-blue-700"
-      >
-        Login with Discord
-      </a>
-    </div>
-  );
+function ProtectedRoute({ user, children }) {
+  return user ? children : <Navigate to="/auth" replace />;
 }
 
 function Dashboard({ user }) {
@@ -29,17 +17,9 @@ function Dashboard({ user }) {
 }
 
 function App() {
-  const [message, setMessage] = useState('Loading...');
   const [user, setUser] = useState(null);
 
   useEffect(() => {
-    fetch(`${config.apiBase}/api/message`)
-      .then((res) => res.json())
-      .then((data) => setMessage(data.message))
-      .catch((err) => {
-        console.error(err);
-        setMessage('Error fetching message');
-      });
     fetch(`${config.apiBase}/api/user`)
       .then((res) => res.json())
       .then((data) => setUser(data.user))
@@ -51,11 +31,18 @@ function App() {
       <div className="min-h-screen flex flex-col items-center justify-center p-8">
         <h1 className="text-4xl font-bold mb-4">Niactyl App</h1>
         <Routes>
-          <Route path="/" element={<Home message={message} user={user} />} />
+          <Route
+            path="/"
+            element={<Navigate to={user ? '/dashboard' : '/auth'} replace />}
+          />
           <Route path="/auth" element={<Auth />} />
           <Route
             path="/dashboard"
-            element={user ? <Dashboard user={user} /> : <Navigate to="/auth" />}
+            element={
+              <ProtectedRoute user={user}>
+                <Dashboard user={user} />
+              </ProtectedRoute>
+            }
           />
         </Routes>
       </div>


### PR DESCRIPTION
## Summary
- require users to authenticate before accessing any page
- restore the old design for the auth page

## Testing
- `npm install`
- `npm install` in `client`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6870222e23ec832bbcc436fe2385c714