### PR TITLE
Fix logout link

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -11,7 +11,9 @@ function Dashboard({ user }) {
   return (
     <div className="text-center">
       <p className="mb-4 text-xl text-gray-300">Welcome, {user.username}!</p>
-      <a href="/logout" className="underline text-blue-400">Logout</a>
+      <a href={`${config.apiBase}/logout`} className="underline text-blue-400">
+        Logout
+      </a>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- point dashboard logout link at API base URL to ensure it works in dev mode

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_687026834550832b96f9df96ffbc8af7