### PR TITLE
Fix logout handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,10 @@ async function start() {
   }
 
   fastify.get('/logout', async (req, reply) => {
-    await req.destroySession();
+    if (req.session) {
+      await req.session.destroy();
+    }
+    reply.clearCookie('sessionId');
     reply.redirect('/');
   });
 


### PR DESCRIPTION
## Summary
- clean up logout handler so `req.destroySession` isn't used

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687029f126e0832b88aa74a637001a75